### PR TITLE
Upgrade to .NET 6

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET Core 3.1 Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/.build/bin/dotnetcowsay/Debug/netcoreapp3.1/dotnet-cowsay.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+            "name": ".NET 6 Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/src/.build/bin/dotnetcowsay/Debug/net6.0/dotnet-cowsay.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-  <Title>dotnet cowsay</Title>
+    <Title>dotnet cowsay</Title>
     <Authors>Isaac Levin</Authors>
     <Product>dotnet-cowsay</Product>
     <Copyright>Copyright © Isaac Levin</Copyright>
@@ -11,6 +11,9 @@
     <PackageProjectUrl>https://github.com/isaac2004/dotnet-cowsay</PackageProjectUrl>
     <RepositoryUrl>https://github.com/isaac2004/dotnet-cowsay.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IsPackable>false</IsPackable>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <LangVersion>Latest</LangVersion>
@@ -19,4 +22,10 @@
     <BaseOutputPath>$(MSBuildThisFileDirectory).build\bin\$(MSBuildProjectName)</BaseOutputPath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,10 +15,6 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <LangVersion>Latest</LangVersion>
     <NeutralLanguage>en</NeutralLanguage>
-
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateFullPaths Condition="'$(VSCODE_PID)' != ''">true</GenerateFullPaths>
-
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory).build\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <BaseOutputPath>$(MSBuildThisFileDirectory).build\bin\$(MSBuildProjectName)</BaseOutputPath>
   </PropertyGroup>

--- a/src/dotnetcowsay.csproj
+++ b/src/dotnetcowsay.csproj
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <RollForward>LatestMajor</RollForward>
     <AssemblyName>dotnet-cowsay</AssemblyName>
     <RootNamespace>dotnetcowsay</RootNamespace>
     <Version>1.0.0</Version>

--- a/src/dotnetcowsay.csproj
+++ b/src/dotnetcowsay.csproj
@@ -5,12 +5,15 @@
     <PackAsTool>True</PackAsTool>
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyName>dotnet-cowsay</AssemblyName>
     <RootNamespace>dotnetcowsay</RootNamespace>
     <Version>1.0.0</Version>
     <Description>.NET Core Global Tool that gives a a random blog post from discoverdot.net</Description>
     <PackageTags>dotnet, global tools, cowsay</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnetcowsay.csproj
+++ b/src/dotnetcowsay.csproj
@@ -5,7 +5,7 @@
     <PackAsTool>True</PackAsTool>
     <IsPackable>true</IsPackable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>dotnet-cowsay</AssemblyName>
     <RootNamespace>dotnetcowsay</RootNamespace>
     <Version>1.0.0</Version>
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Kurukuru" Version="1.0.0" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Kurukuru" Version="1.4.2" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1.  Upgrade build SDK to .NET 6.
2.  Make it SDK version tolerate by adding `<RollForward>LatestMajor</RollForward>`, see: https://docs.microsoft.com/en-us/dotnet/core/versions/selection#control-roll-forward-behavior
3.  Add GitHub SourceLink support.
4.  Add Visual Studio Code debug configuration file.